### PR TITLE
Fix the cmyk function for the color black

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -540,6 +540,9 @@ end
 function Color:cmyk()
   local r, g, b = self.r, self.g, self.b
   local K = math.max(r, g, b)
+  if K == 0 then
+     return 0.0, 0.0, 0.0, 1.0
+  end
   local k = 1 - K
   local c = (K - r) / K
   local m = (K - g) / K


### PR DESCRIPTION
For the color black, the variable `K` is `0`. Lua interprets `0 / 0` as `-nan`

https://github.com/Firanel/lua-color/blob/eba73e53e9abd2e8da4d56b016fd77b45c2f3b79/init.lua#L540-L548

```lua
color = Color('#ffffff')
print(color:cmyk()) -- -nan	-nan	-nan	1.0
```